### PR TITLE
Fix cron reload - only supports restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,4 @@
 - name: reload cron
   service:
     name: cron
-    state: reloaded
+    state: restarted


### PR DESCRIPTION
While `service cron reload` works, ansible apparently can only handle restart.