### PR TITLE
Add platforms to galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,14 @@ galaxy_info:
 
   min_ansible_version: "2.10"
 
+  platforms:
+  - name: Debian
+    versions:
+    - all
+  - name: Ubuntu
+    versions:
+    - all
+
   galaxy_tags:
   - cron
   - dehydrated


### PR DESCRIPTION
This role is tied to Debian or Ubuntu systems. State this in the Galaxy meta-data.