### PR TITLE
Continue with the next certificate on error

### DIFF
--- a/templates/dehy-wrap.sh.j2
+++ b/templates/dehy-wrap.sh.j2
@@ -2,7 +2,7 @@
 
 DOMAINS="{{ dehydrated_config_dir }}/domains.txt"
 DEHYDRATED="{{ dehydrated_binary }}"
-CALL="$DEHYDRATED -c"
+CALL="$DEHYDRATED -c -g"
 
 RESULT=$($CALL)
 RETURN=$?


### PR DESCRIPTION
Sometimes creating a specific certificate fails and dehydrated completely stops, starving other services from their certificates.

Add the `-g` CLI option to make dehydrated continue through all domains.